### PR TITLE
[Bug] Cannot use 'in' operator to search for 'subscribe' in value

### DIFF
--- a/src/utils/isSvelteStore.ts
+++ b/src/utils/isSvelteStore.ts
@@ -4,5 +4,9 @@ import { Readable } from 'svelte/store';
 export function isSvelteStore<TStore extends object>(
 	obj: StoreOrVal<TStore>,
 ): obj is Readable<TStore> {
-	return 'subscribe' in obj && typeof obj.subscribe === 'function';
+	return (
+		typeof obj === 'object' &&
+		'subscribe' in obj &&
+		typeof obj.subscribe === 'function'
+	);
 }


### PR DESCRIPTION
Queries can have regular values as input and you can't use in operator on primitives this PR adds an additional check for Svelte stores. 

On this line the app errors with primitive values as inputs in queries.
https://github.com/ottomated/trpc-svelte-query/blob/960fbf9e378c9fd174ea36d23da6701201a71df6/src/createTRPCSvelte.ts#L223