### PR TITLE
Fix types when using select with queries

### DIFF
--- a/src/createTRPCSvelte.ts
+++ b/src/createTRPCSvelte.ts
@@ -66,23 +66,23 @@ export type UserExposedOptions<TOptions> =
 type DecorateProcedure<TProcedure extends AnyProcedure> =
 	TProcedure extends AnyQueryProcedure
 		? {
-				query: (
+				query: <TData = inferTransformedProcedureOutput<TProcedure>>(
 					input: StoreOrVal<inferProcedureInput<TProcedure>>,
 					options?: StoreOrVal<
 						UserExposedOptions<
 							CreateQueryOptions<
 								inferTransformedProcedureOutput<TProcedure>,
-								TRPCClientErrorLike<TProcedure>
+								TRPCClientErrorLike<TProcedure>,
+								TData
 							>
 						>
 					>,
-				) => CreateQueryResult<
-					inferTransformedProcedureOutput<TProcedure>,
-					TRPCClientErrorLike<TProcedure>
-				>;
+				) => CreateQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
 		  } & (inferProcedureInput<TProcedure> extends { cursor?: any }
 				? {
-						infiniteQuery: (
+						infiniteQuery: <
+							TData = inferTransformedProcedureOutput<TProcedure>,
+						>(
 							input: StoreOrVal<
 								Omit<inferProcedureInput<TProcedure>, 'cursor'>
 							>,
@@ -90,12 +90,13 @@ type DecorateProcedure<TProcedure extends AnyProcedure> =
 								UserExposedOptions<
 									CreateInfiniteQueryOptions<
 										inferTransformedProcedureOutput<TProcedure>,
-										TRPCClientErrorLike<TProcedure>
+										TRPCClientErrorLike<TProcedure>,
+										TData
 									>
 								>
 							>,
 						) => CreateInfiniteQueryResult<
-							inferTransformedProcedureOutput<TProcedure>,
+							TData,
 							TRPCClientErrorLike<TProcedure>
 						>;
 				  }


### PR DESCRIPTION
Currently when select transforms data shape(say, you fetch an array but then use select to get its length) - typescript will complain that select's return type is incompatible with data type.
This PR addressed that - now if you don't use select the type will be kept as is from procedure output. If you do - query data property type will be of whatever is returned by select function

Also fixed key type a little bit - it doesn't get inferred literally even tho theoretically that's doable(user.reviews.findAll -> [['user','reviews','findAll']] can be done), but at least it's of your QueryKey type instead of unknown now.

Also closes #10 - infinite queries now return correct type with page and page params and also next page parameter gets inferred correctly from cursor instead of unkown.
