### PR TITLE
Update +layout.server.ts of ssr example to prevent type error

### DIFF
--- a/examples/sveltekit-ssr/src/routes/+layout.server.ts
+++ b/examples/sveltekit-ssr/src/routes/+layout.server.ts
@@ -3,6 +3,6 @@ import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async (event) => {
   return {
-		trpc: trpcServer.hydrateToClient(event),
+		trpc: await trpcServer.hydrateToClient(event),
   };
 };


### PR DESCRIPTION
Was getting a type error in the +layout.svelte file when creating the query client because it was expecting a resolved promise in `trpc.hydrateFromServer` 